### PR TITLE
Encode NaN as null

### DIFF
--- a/src/main/scala/sangria/marshalling/circe.scala
+++ b/src/main/scala/sangria/marshalling/circe.scala
@@ -25,8 +25,8 @@ object circe {
       case v: Boolean ⇒ Json.fromBoolean(v)
       case v: Int ⇒ Json.fromInt(v)
       case v: Long ⇒ Json.fromLong(v)
-      case v: Float ⇒ Json.fromDouble(v).get
-      case v: Double ⇒ Json.fromDouble(v).get
+      case v: Float ⇒ Json.fromDoubleOrNull(v)
+      case v: Double ⇒ Json.fromDoubleOrNull(v)
       case v: BigInt ⇒ Json.fromBigInt(v)
       case v: BigDecimal ⇒ Json.fromBigDecimal(v)
       case v ⇒ throw new IllegalArgumentException("Unsupported scalar value: " + v)

--- a/src/main/scala/sangria/marshalling/circe.scala
+++ b/src/main/scala/sangria/marshalling/circe.scala
@@ -55,17 +55,18 @@ object circe {
     def getListValue(node: Json) = node.asArray.get
 
     def isDefined(node: Json) = !node.isNull
-    def getScalarValue(node: Json) =
-      if (node.isBoolean)
-        node.asBoolean.get
-      else if (node.isNumber) {
-        val num = node.asNumber.get
-        
-        (num.toBigInt orElse num.toBigDecimal).get
-      } else if (node.isString)
-        node.asString.get
-      else
-        throw new IllegalStateException(s"$node is not a scalar value")
+    def getScalarValue(node: Json) = {
+      def invalidScalar = throw new IllegalStateException(s"$node is not a scalar value")
+
+      node.fold(
+        jsonNull = invalidScalar,
+        jsonBoolean = identity,
+        jsonNumber = num ⇒ num.toBigInt orElse num.toBigDecimal getOrElse invalidScalar,
+        jsonString = identity,
+        jsonArray = _ ⇒ invalidScalar,
+        jsonObject = _ ⇒ invalidScalar
+      )
+    }
 
     def getScalaScalarValue(node: Json) = getScalarValue(node)
 


### PR DESCRIPTION
While migrating from the Spray JSON marshaller to Circe I experienced the following error:
```
backend[ERROR] java.util.NoSuchElementException: None.get
backend[ERROR] 	at scala.None$.get(Option.scala:347)
backend[ERROR] 	at scala.None$.get(Option.scala:345)
backend[ERROR] 	at sangria.marshalling.circe$.intro(circe.scala:85)
backend[ERROR] 	at sangria.marshalling.circe$CirceResultMarshaller$.scalarNode(circe.scala:29)
backend[ERROR] 	at sangria.marshalling.circe$CirceResultMarshaller$.scalarNode(circe.scala:7)
backend[ERROR] 	at sangria.execution.Resolver$.marshalScalarValue(Resolver.scala:1032)
backend[ERROR] 	at sangria.execution.Resolver.resolveValue(Resolver.scala:667)
backend[ERROR] 	at sangria.execution.Resolver$$anonfun$24.apply(Resolver.scala:399)
backend[ERROR] 	at sangria.execution.Resolver$$anonfun$24.apply(Resolver.scala:393)
```

I think it would be better to adopt Circe's [encoding for NaN] since users of the Circe marshalling library should be familiar with it.

[encoding for NaN]: https://github.com/travisbrown/circe/blob/360a61c1763afbbeba796d2356a2515eaa461ed1/modules/core/shared/src/main/scala/io/circe/Decoder.scala#L430