### PR TITLE
Upgrade circe to 0.6.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,10 @@ licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/
 scalaVersion := "2.11.8"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
-val circeVersion = "0.5.4"
+val circeVersion = "0.6.0-RC1"
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "0.2.1",
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "0.2.2",
 
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/src/main/scala/sangria/marshalling/circe.scala
+++ b/src/main/scala/sangria/marshalling/circe.scala
@@ -1,7 +1,6 @@
 package sangria.marshalling
 
 import io.circe._
-import cats.data.Xor.{Right, Left}
 
 object circe {
   implicit object CirceResultMarshaller extends ResultMarshaller {


### PR DESCRIPTION
Circe now depends on cats 0.8 which removed Xor in favour of Scala 2.12's right-biased Either.

Also bump the marshalling API to the newest version.

---

No 2.12.0 artifacts has been released of circe yet at this point and 0.6.0-RC1 is only available for 2.12.0-RC2, but if you want to keep master in a releasable state this PR should not be merged. Anyway it is quite trivial.