### PR TITLE
feat!: make json object a scalar

### DIFF
--- a/src/test/scala/sangria/marshalling/CirceSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/CirceSupportSpec.scala
@@ -32,11 +32,6 @@ class CirceSupportSpec
   )
 
   "InputUnmarshaller" should {
-    "throw an exception on invalid scalar values" in {
-      an[IllegalStateException] should be thrownBy
-        CirceInputUnmarshaller.getScalarValue(Json.obj())
-    }
-
     "throw an exception on variable names" in {
       an[IllegalArgumentException] should be thrownBy
         CirceInputUnmarshaller.getVariableName(Json.fromString("$foo"))


### PR DESCRIPTION
please review 🙏

### Motivation
This PR is part of the series that aims to make federation possible in Sangria, and it comes as a response to the federation issue discussed [here](https://github.com/sangria-graphql/sangria/issues/462).

### Changes
This PR implements the new contract described in the [testkit PR](https://github.com/sangria-graphql/sangria-marshalling-testkit/pull/22), by ensuring that json objects are GraphQL scalars.

### Consequences
- By accepting these changes, any sangria application using the circe marshaller will be able to accept json objects (in variables) as scalars. In particular, let's assume the following schema :
  ```
  scalar _Any
  type Query {
    _entities(representations: [_Any!]!): [_Entity]!
  } 
  ```
  with these changes, we can execute these kind of queries (**see how  a json object is passed as a scalar**):
  ```
  {
    "query": "query($representations: [_Any!]!) {...}"
    "variables": {
      "_representations": [
        {
          "__typename": "Product",
          "upc": "B00005N5PF"
        },
        ...
      ]
    }
  }
  ``` 
- As for the risks, they are the same as discussed [here]((https://github.com/sangria-graphql/sangria-marshalling-testkit/pull/22). Basically, extra care must be taking on the application side to ensure that the scalar json objects are not misused.

### Notes for reviewer
At the current moment, tests fail because the PR still requires a new release of the testkit, incorporating the changes proposed [here](https://github.com/sangria-graphql/sangria-marshalling-testkit/pull/22). Once, the new release has been published, another commit should be done updating the build with the new version.
