### PR TITLE
feat: add any input unmarshaller

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ javacOptions ++= Seq("-source", "8", "-target", "8")
 val circeVersion = "0.13.0"
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.5",
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.6-SNAPSHOT",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion % Test,
   "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.3" % Test,


### PR DESCRIPTION
### Motivation
The PR adds an input unmarshaller that allows json objects to be scalars, it came as a response to the issue discussed [here](https://github.com/sangria-graphql/sangria/issues/575).

### Changes
A tagged type **Json @@ AnySupport** is used to differentiate the unmarshaller from the **Json** one. Now, anyone that wants to allow AnySupport can just use the tag as a type argument for the input type parameter in the executor.